### PR TITLE
Wrong chat in defender for varrock

### DIFF
--- a/src/Quest Data/QuestDetail.json
+++ b/src/Quest Data/QuestDetail.json
@@ -2009,7 +2009,6 @@
 		],
 		"ItemsRequired": [
 			"3 different kinds of food: 6 of 1 type and 7 of 2 others for a total of 20 pieces.",
-			"Goutweed",
 			"1 astral rune"
 		],
 		"Recommended": [

--- a/src/Quests/Defender of Varrock/DefenderOfVarrockInfo.txt
+++ b/src/Quests/Defender of Varrock/DefenderOfVarrockInfo.txt
@@ -23,7 +23,7 @@ Talk to Ramarno. (Chat 4) If you have a redberry pie you can give it to Ramarno 
 Use blurite ore on the forge.`
 Talk to Ramarno for a cutscene.`
 Return to Captain Rovin, ignoring the zombies. He gives you a restored shield.`
-Talk to Reldo in the library on the 1st floor[US]. (Chat 4) or (Chat 5) if TokTz-Ket-Dill has been completed.`
+Talk to Reldo in the library on the 1st floor[US]. (Chat 3) or (Chat 4) if TokTz-Ket-Dill has been completed.`
 Read the Varrock Census on the lectern.`
 Search the scrolls on the floor a few steps south after talking to Reldo about the situation.`
 Read the list of elders scroll.`


### PR DESCRIPTION
It's chat 3 I believe
![chat 3](https://github.com/user-attachments/assets/6fddad93-7a3b-42ed-b2a9-03d5b6c29101)
