### PR TITLE
Fix defender of varrock chat option

### DIFF
--- a/src/Quests/Defender of Varrock/DefenderOfVarrockInfo.txt
+++ b/src/Quests/Defender of Varrock/DefenderOfVarrockInfo.txt
@@ -23,7 +23,7 @@ Talk to Ramarno. (Chat 4) If you have a redberry pie you can give it to Ramarno 
 Use blurite ore on the forge.`
 Talk to Ramarno for a cutscene.`
 Return to Captain Rovin, ignoring the zombies. He gives you a restored shield.`
-Talk to Reldo in the library on the 1st floor[US]. (Chat 4) or (Chat 5) if TokTz-Ket-Dill has been completed.`
+Talk to Reldo in the library on the 1st floor[US]. (Chat 3) or (Chat 4) if TokTz-Ket-Dill has been completed.`
 Read the Varrock Census on the lectern.`
 Search the scrolls on the floor a few steps south after talking to Reldo about the situation.`
 Read the list of elders scroll.`

--- a/src/Quests/Missing My Mummy/MissingMyMummyInfo.txt
+++ b/src/Quests/Missing My Mummy/MissingMyMummyInfo.txt
@@ -29,7 +29,7 @@ Kill the golem and descend the stairs (You may be placed in the mummy's tomb aft
 Find a path of blue and green blocks or of red and yellow blocks all the way through.`
 Go across the tiled room and collect the first canopic jar to the west of the northern staircase.`
 If you spawn at the bottom of the northern staircase simply pick up the canopic jar to the west.`
-Collect the two remaining canopic jars and mummy with no hand in the tunnels. The fourth can be found on one of the skeleton bodies upstairs, "Rummage" them and defeat them.`
+Collect the two remaining canopic jars and mummy with no hand in the tunnels. One canopic jar can be found to the east and the other to the south next to the mummy with no hand. The fourth can be found on one of the skeleton bodies upstairs, "Rummage" them and defeat them.`
 Use the mummy hand on the mummy with no hand.`
 Return to the tiled room and cross back towards the Empty Sarcophagus.`
 You may go upstairs, and back downstairs to teleport to the tomb room to skip the tile puzzle.`
@@ -39,7 +39,7 @@ Fill the empty sarcophagus.`
 Pray at the 5 broken statues.`
 Repair the chair and table.`
 Replace the pot and jug.`
-Run east and kill the shadow. Then light the enchanted sconces in the following order: south, north, west, east. Shadows will spawn and must be killed between each sconce lighting.`
+Run east and kill the shadow. Then light the enchanted sconces in the following order: south, north, west, east. Shadows will spawn and must be killed between each sconce lighting. You must kill the shadow 5 times for 100% completion.` 
 Return to the Queen's chamber and create the statue on the empty base, then carve it 2 times.`
 Talk to the Pharaoh Queen who has appeared in front of the table to give her the 3 papyri. (Chat 5) (Not required for quest completion, only for 100% rebuild)`
 Right-click check-progress on your scroll of the dead or pyramid journal to verify you've rebuilt the mummy 75%, otherwise check any parts missed. (Or 100% if you want to finish the mummy)`


### PR DESCRIPTION
![chat 3](https://github.com/user-attachments/assets/93d9aa57-f5be-40a8-8a3a-7456cc777ce7)
There is no chat 4 option only chat 3, I believe this is the correct fix